### PR TITLE
Fix c++ tyop

### DIFF
--- a/acoustic_algorithm/include/esp_ns.h
+++ b/acoustic_algorithm/include/esp_ns.h
@@ -64,7 +64,7 @@ void ns_process(ns_handle_t inst, int16_t *indata, int16_t *outdata);
 void ns_destroy(ns_handle_t inst);
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif //_ESP_NS_H_


### PR DESCRIPTION
Accidentially, extern "C" was reopened instead of closed