### PR TITLE
fix component.mk issue in legacy GNU make

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -1,15 +1,17 @@
 COMPONENT_ADD_INCLUDEDIRS := lib/include \
                              wake_word_engine/include \
-	                         speech_command_recognition/include \
-							 acoustic_algorithm/include \
+                             speech_command_recognition/include \
+                             acoustic_algorithm/include \
+                             esp-tts/esp_tts_chinese/include \
 
-COMPONENT_SRCDIRS := speech_command_recognition 
-	                 
+COMPONENT_SRCDIRS := speech_command_recognition
+
 
 LIB_FILES := $(shell ls $(COMPONENT_PATH)/wake_word_engine/lib*.a) \
-	         $(shell ls $(COMPONENT_PATH)/lib/lib*.a) \
-	         $(shell ls $(COMPONENT_PATH)/acoustic_algorithm/lib*.a) \
-	         $(shell ls $(COMPONENT_PATH)/speech_command_recognition/lib*.a) \
+             $(shell ls $(COMPONENT_PATH)/lib/lib*.a) \
+             $(shell ls $(COMPONENT_PATH)/acoustic_algorithm/lib*.a) \
+             $(shell ls $(COMPONENT_PATH)/speech_command_recognition/lib*.a) \
+             $(shell ls $(COMPONENT_PATH)/esp-tts/esp_tts_chinese/lib*.a) \
 
 LIBS := $(patsubst lib%.a,-l%,$(LIB_FILES))
 
@@ -17,5 +19,6 @@ COMPONENT_ADD_LDFLAGS +=  -L$(COMPONENT_PATH)/lib \
                           -L$(COMPONENT_PATH)/wake_word_engine \
                           -L$(COMPONENT_PATH)/speech_command_recognition \
                           -L$(COMPONENT_PATH)/acoustic_algorithm \
-						  $(LIBS)
+                          -L$(COMPONENT_PATH)/esp-tts \
+                          $(LIBS)
 


### PR DESCRIPTION
This PR fixes a problem with the legacy GNU make, then compiler can not finding the esp_tts.h header issue. @feizi 