### PR TITLE
Added c++ linkage defines to acoustic_algorithm headers

### DIFF
--- a/acoustic_algorithm/include/esp_agc.h
+++ b/acoustic_algorithm/include/esp_agc.h
@@ -14,6 +14,10 @@
 #ifndef _ESP_AGC_H_
 #define _ESP_AGC_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 ////all positive value is valid, negective is error
 typedef enum {
     ESP_AGC_SUCCESS = 0,   ////success
@@ -27,5 +31,9 @@ void *esp_agc_open(int agc_mode, int sample_rate);
 void set_agc_config(void *agc_handle, int gain_dB, int limiter_enable, int target_level_dbfs);
 int esp_agc_process(void *agc_handle, short *in_pcm, short *out_pcm, int frame_size, int sample_rate);
 void esp_agc_clse(void *agc_handle);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _ESP_AGC_H_

--- a/acoustic_algorithm/include/esp_map.h
+++ b/acoustic_algorithm/include/esp_map.h
@@ -11,6 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License
+#ifndef _ESP_MAP_H_
+#define _ESP_MAP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define MAP_SAMPLE_RATE 16000        // Supports 16kHz only
 #define MAP_FRAME_SIZE 16            // Supports 16ms only
@@ -76,3 +82,9 @@ void map_process(mic_array_processor_t st, int16_t *in, int16_t *far_end, int16_
  *
  */
 void map_destory(mic_array_processor_t st);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/acoustic_algorithm/include/esp_mase.h
+++ b/acoustic_algorithm/include/esp_mase.h
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License
 
+#ifndef _ESP_MASE_H_
+#define _ESP_MASE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MASE_SAMPLE_RATE 16000        // Supports 16kHz only
 #define MASE_FRAME_SIZE 16            // Supports 16ms only
 #define MASE_MIC_DISTANCE 65          // According to physical design of mic-array
@@ -79,3 +86,9 @@ void mase_process(mase_handle_t st, int16_t *in, int16_t *dsp_out);
  *
  */
 void mase_destory(mase_handle_t st);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/acoustic_algorithm/include/esp_ns.h
+++ b/acoustic_algorithm/include/esp_ns.h
@@ -79,7 +79,7 @@ void ns_process(ns_handle_t inst, int16_t *indata, int16_t *outdata);
 void ns_destroy(ns_handle_t inst);
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif //_ESP_NS_H_


### PR DESCRIPTION
Correcting errors mentioned in issue #23: "error in linkage for cpp projects -> esp_ns.h"

Corrected bug in `esp_ns.h` -> not closing `extern "C" {` brackets. Is only relevant for cpp projects as the pre-compiler defines remove the code in c.

Added similar linkage to the rest of the headers in the folder.